### PR TITLE
Add toggle for red-green colorblind mode

### DIFF
--- a/src/pages/rankings/TrueRankingsTable.js
+++ b/src/pages/rankings/TrueRankingsTable.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import {
   Table,
@@ -10,7 +10,10 @@ import {
   TableRow,
   Paper,
   Avatar,
-  Typography
+  Typography,
+  FormControlLabel,
+  Switch,
+  Grid
 } from '@material-ui/core';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { getPowerRankings } from '../../api/FantasyFootballApiv2';
@@ -31,24 +34,26 @@ const useStyles = makeStyles(theme => ({
   Should return a dark red for bad record and dark green for a good record,
   mediocre records should be light red/green
 */
-const getHslCellColor = (wins, losses) => {
+const getHslCellColor = (wins, losses, colorBlindMode) => {
+  const red = colorBlindMode ? '323' : '0';
+  const green = colorBlindMode ? '103' : '100';
   const totalGames = losses + wins;
   if (wins < losses) {
     const winPercentage = wins / totalGames;
-    return `hsl(0, 65%,${(winPercentage + 0.5) * 100}%)`;
+    return `hsl(${red}, 65%,${(winPercentage + 0.5) * 100}%)`;
   } else {
     const lossPercentage = losses / totalGames;
-    return `hsl(100, 65%,${(lossPercentage + 0.4) * 100}%)`;
+    return `hsl(${green}, 65%,${(lossPercentage + 0.4) * 100}%)`;
   }
 };
 
-const displayWeeklyRecords = (team, totalTeams) => {
+const displayWeeklyRecords = (team, totalTeams, colorBlindMode) => {
   return team.wins.map((wins, index) => {
     const losses = totalTeams - 1 - wins;
     return (
       <TableCell
         align="center"
-        css={{ padding: '10px', backgroundColor: getHslCellColor(wins, losses) }}
+        css={{ padding: '10px', backgroundColor: getHslCellColor(wins, losses, colorBlindMode) }}
         key={`record-${index}`}
       >
         {wins} - {losses}
@@ -91,6 +96,7 @@ export default function TrueRankinsTable(props) {
   const [rankings, setRankings] = useState([]);
   const [loading, setLoading] = useState(false);
   const [showAlert, setShowAlert] = useState(false);
+  const [colorBlindMode, setColorBlindMode] = useState(false);
   const { leagueId, seasonId = 2019 } = props;
 
   useEffect(() => {
@@ -127,51 +133,66 @@ export default function TrueRankinsTable(props) {
     <Paper className={classes.root}>
       <AlertDialog open={showAlert} handleClose={() => setShowAlert(false)} />
       {rankings.length > 0 && (
-        <Table>
-          <TableHead>
-            <TableRow>
-              <StyledTableCell css={{ minWidth: isLargeScreen ? '250px' : undefined }}>
-                Team
-              </StyledTableCell>
-              {isLargeScreen && displayWeeklyHeaders(rankings)}
-              <StyledTableCell
-                align="center"
-                css={{ minWidth: isLargeScreen ? '100px' : undefined }}
-              >
-                Simulated Record
-              </StyledTableCell>
-              <StyledTableCell
-                align="center"
-                css={{ minWidth: isLargeScreen ? '100px' : undefined }}
-              >
-                ESPN Record
-              </StyledTableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {rankings.map(row => (
-              <TableRow key={row.name}>
-                <StyledTableCell>
-                  <div css={{ display: 'flex', alignItems: 'center' }}>
-                    {isLargeScreen && <Avatar alt={row.name} src={row.logo} />}
-                    <TeamName name={row.name} isLargeScreen={isLargeScreen} />
-                  </div>
+        <React.Fragment>
+          <Grid container direction="row-reverse" justify="flex-start" alignItems="center">
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={colorBlindMode}
+                  onChange={() => setColorBlindMode(!colorBlindMode)}
+                  value="colorBlindMode"
+                  color="primary"
+                />
+              }
+              label="Color Blind Mode"
+            />
+          </Grid>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <StyledTableCell css={{ minWidth: isLargeScreen ? '250px' : undefined }}>
+                  Team
                 </StyledTableCell>
-                {isLargeScreen && displayWeeklyRecords(row, rankings.length)}
-                <StyledTableCell align="center" className="simulated-record-cell">
-                  <Typography variant="body1" css={{ fontWeight: '600' }}>
-                    {row.totalWins} - {row.totalLosses}
-                  </Typography>
+                {isLargeScreen && displayWeeklyHeaders(rankings)}
+                <StyledTableCell
+                  align="center"
+                  css={{ minWidth: isLargeScreen ? '100px' : undefined }}
+                >
+                  Simulated Record
                 </StyledTableCell>
-                <StyledTableCell align="center" className="actual-record-cell">
-                  <Typography variant="body1">
-                    {row.actualRecord.wins} - {row.actualRecord.losses}
-                  </Typography>
+                <StyledTableCell
+                  align="center"
+                  css={{ minWidth: isLargeScreen ? '100px' : undefined }}
+                >
+                  ESPN Record
                 </StyledTableCell>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+            </TableHead>
+            <TableBody>
+              {rankings.map(row => (
+                <TableRow key={row.name}>
+                  <StyledTableCell>
+                    <div css={{ display: 'flex', alignItems: 'center' }}>
+                      {isLargeScreen && <Avatar alt={row.name} src={row.logo} />}
+                      <TeamName name={row.name} isLargeScreen={isLargeScreen} />
+                    </div>
+                  </StyledTableCell>
+                  {isLargeScreen && displayWeeklyRecords(row, rankings.length, colorBlindMode)}
+                  <StyledTableCell align="center" className="simulated-record-cell">
+                    <Typography variant="body1" css={{ fontWeight: '600' }}>
+                      {row.totalWins} - {row.totalLosses}
+                    </Typography>
+                  </StyledTableCell>
+                  <StyledTableCell align="center" className="actual-record-cell">
+                    <Typography variant="body1">
+                      {row.actualRecord.wins} - {row.actualRecord.losses}
+                    </Typography>
+                  </StyledTableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </React.Fragment>
       )}
     </Paper>
   );


### PR DESCRIPTION
Hey! This is a really cool project. I completely understand if you don't want to add this as it's not documented anywhere as an issue and does add some more clutter to the UI, I just thought it might be neat to add a color blind mode toggle to the Standings Simulator table to help folks with red-green colorblindness be able to distinguish the colors a bit better.

I took the colors from the first example in this blog post: https://www.visualisingdata.com/2015/11/colour-swatch-alternatives-to-green-and-red/ I don't have red-green colorblindness myself, so I can't actually test that it works.

Here is the toggle in action:
![color-blind-mode](https://user-images.githubusercontent.com/3903208/67622694-9c684d80-f7ea-11e9-8cf7-0778a55a56a2.gif)
